### PR TITLE
updated implementation of make_grid_ds

### DIFF
--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -1,8 +1,10 @@
+import numpy as np
 import pytest
 import xarray as xr
 from zarr.storage import MemoryStore
 
 from ndpyramid import pyramid_coarsen, pyramid_regrid, pyramid_reproject
+from ndpyramid.regrid import make_grid_ds
 
 
 @pytest.fixture
@@ -36,3 +38,10 @@ def test_regridded_pyramid(temperature):
     pyramid = pyramid_regrid(temperature, levels=2)
     assert pyramid.ds.attrs['multiscales']
     pyramid.to_zarr(MemoryStore())
+
+
+def test_make_grid_ds():
+
+    grid = make_grid_ds(0, pixels_per_tile=8)
+    lon_vals = grid.lon_b.values
+    assert np.isclose(lon_vals[-1, :] + lon_vals[0, :], 0)

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -44,4 +44,4 @@ def test_make_grid_ds():
 
     grid = make_grid_ds(0, pixels_per_tile=8)
     lon_vals = grid.lon_b.values
-    assert np.isclose(lon_vals[-1, :] + lon_vals[0, :], 0)
+    assert np.all((lon_vals[-1, :] + lon_vals[0, :]) < 0.001)


### PR DESCRIPTION
This PR addresses some issues we've been noticing when using the `pyramid_reproject` function with climate model data. Previous versions of the target grid were resulting in gaps at the dateline (or prime meridian). A more careful implantation of cell centers/boundaries is now included here.