### PR TITLE
Allow passing `keep_attrs`, `skipna` to xESMF regridder

### DIFF
--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -35,8 +35,10 @@ def test_reprojected_pyramid(temperature):
 
 def test_regridded_pyramid(temperature):
     xesmf = pytest.importorskip('xesmf')  # noqa: F841
-    pyramid = pyramid_regrid(temperature, levels=2)
+    pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws={'keep_attrs': True})
     assert pyramid.ds.attrs['multiscales']
+    assert pyramid['0'].ds.air.attrs == temperature['air'].attrs
+    assert pyramid['1'].ds.air.attrs == temperature['air'].attrs
     pyramid.to_zarr(MemoryStore())
 
 

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -32,12 +32,16 @@ def test_reprojected_pyramid(temperature):
     pyramid.to_zarr(MemoryStore())
 
 
-@pytest.mark.parametrize('keep_attrs', [True, False])
-def test_regridded_pyramid(temperature, keep_attrs):
+@pytest.mark.parametrize('regridder_apply_kws', [None, {'keep_attrs': True}])
+def test_regridded_pyramid(temperature, regridder_apply_kws):
     pytest.importorskip('xesmf')
-    pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws={'keep_attrs': keep_attrs})
+    pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws=regridder_apply_kws)
     assert pyramid.ds.attrs['multiscales']
-    expected_attrs = temperature['air'].attrs if keep_attrs else {}
+    expected_attrs = (
+        temperature['air'].attrs
+        if regridder_apply_kws is not None and regridder_apply_kws['keep_attrs']
+        else {}
+    )
     assert pyramid['0'].ds.air.attrs == expected_attrs
     assert pyramid['1'].ds.air.attrs == expected_attrs
     pyramid.to_zarr(MemoryStore())

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -15,7 +15,6 @@ def temperature():
 
 
 def test_xarray_coarsened_pyramid(temperature):
-    print(temperature)
     factors = [4, 2, 1]
     pyramid = pyramid_coarsen(temperature, dims=('lat', 'lon'), factors=factors, boundary='trim')
     assert pyramid.ds.attrs['multiscales']
@@ -23,8 +22,8 @@ def test_xarray_coarsened_pyramid(temperature):
     pyramid.to_zarr(MemoryStore())
 
 
+@pytest.importorskip('rioxarray')
 def test_reprojected_pyramid(temperature):
-    rioxarray = pytest.importorskip('rioxarray')  # noqa: F841
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
     pyramid = pyramid_reproject(temperature, levels=2)

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -23,7 +23,7 @@ def test_xarray_coarsened_pyramid(temperature):
 
 
 def test_reprojected_pyramid(temperature):
-    rioxarray = pytest.importorskip('rioxarray')  # noqa: F841
+    pytest.importorskip('rioxarray')
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
     pyramid = pyramid_reproject(temperature, levels=2)
@@ -32,9 +32,9 @@ def test_reprojected_pyramid(temperature):
     pyramid.to_zarr(MemoryStore())
 
 
-@pytest.importorskip('xesmf')
 @pytest.mark.parametrize('keep_attrs', [True, False])
 def test_regridded_pyramid(temperature, keep_attrs):
+    pytest.importorskip('xesmf')
     pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws={'keep_attrs': keep_attrs})
     assert pyramid.ds.attrs['multiscales']
     expected_attrs = temperature['air'].attrs if keep_attrs else {}

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -22,8 +22,8 @@ def test_xarray_coarsened_pyramid(temperature):
     pyramid.to_zarr(MemoryStore())
 
 
-@pytest.importorskip('rioxarray')
 def test_reprojected_pyramid(temperature):
+    rioxarray = pytest.importorskip('rioxarray')  # noqa: F841
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
     pyramid = pyramid_reproject(temperature, levels=2)

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -33,12 +33,15 @@ def test_reprojected_pyramid(temperature):
     pyramid.to_zarr(MemoryStore())
 
 
-def test_regridded_pyramid(temperature):
-    xesmf = pytest.importorskip('xesmf')  # noqa: F841
-    pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws={'keep_attrs': True})
+@pytest.importorskip('xesmf')
+@pytest.mark.parametrize(
+    'keep_attrs, expected_attrs', [(True, temperature['air'].attrs), (False, {})]
+)
+def test_regridded_pyramid(temperature, keep_attrs, expected_attrs):
+    pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws={'keep_attrs': keep_attrs})
     assert pyramid.ds.attrs['multiscales']
-    assert pyramid['0'].ds.air.attrs == temperature['air'].attrs
-    assert pyramid['1'].ds.air.attrs == temperature['air'].attrs
+    assert pyramid['0'].ds.air.attrs == expected_attrs
+    assert pyramid['1'].ds.air.attrs == expected_attrs
     pyramid.to_zarr(MemoryStore())
 
 

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -34,12 +34,11 @@ def test_reprojected_pyramid(temperature):
 
 
 @pytest.importorskip('xesmf')
-@pytest.mark.parametrize(
-    'keep_attrs, expected_attrs', [(True, temperature['air'].attrs), (False, {})]
-)
-def test_regridded_pyramid(temperature, keep_attrs, expected_attrs):
+@pytest.mark.parametrize('keep_attrs', [True, False])
+def test_regridded_pyramid(temperature, keep_attrs):
     pyramid = pyramid_regrid(temperature, levels=2, regridder_apply_kws={'keep_attrs': keep_attrs})
     assert pyramid.ds.attrs['multiscales']
+    expected_attrs = temperature['air'].attrs if keep_attrs else {}
     assert pyramid['0'].ds.air.attrs == expected_attrs
     assert pyramid['1'].ds.air.attrs == expected_attrs
     pyramid.to_zarr(MemoryStore())


### PR DESCRIPTION
This PR allows users to pass additional keyword arguments (namely `keep_attrs`, `skipna`, and `thres`) to the xESFM regridder during the regridding steps. 