### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,28 @@ A small utility for generating ND array pyramids using Xarray and Zarr.
 
 # installation
 
+Ndpyramid can be installed in three ways:
+
+Using the [conda](https://conda.io) package manager that comes with the Anaconda/Miniconda distribution:
+
 ```shell
-pip install ndpyramid
+conda install ndpyramid --channel conda-forge
 ```
+
+Using the [pip](https://pypi.org/project/pip/) package manager:
+
+```shell
+python -m pip install ndpyramid
+```
+
+To install a development version from source:
+
+```python
+git clone https://github.com/carbonplan/ndpyramid
+cd ndpyramid
+python -m pip install -e .
+```
+
 
 # usage
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ cd ndpyramid
 python -m pip install -e .
 ```
 
-
 # usage
 
 Ndpyramid provides a set of utilites for creating pyramids with standardized metadata.


### PR DESCRIPTION
Now that `ndpyramid` is available via `conda-forge`: https://github.com/conda-forge/ndpyramid-feedstock, this PR updates installation instructions to reflect this new installation option. 
