### PR TITLE
Update utils.py

### DIFF
--- a/ndpyramid/utils.py
+++ b/ndpyramid/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations  # noqa: F401
 
 import contextlib
 
-import cf_xarray  # noqa: F401
 import datatree as dt
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
Removes `import cf_xarray  # noqa: F401`. This is causing a pytest error in `cmip6_downscaling`. `cf_xarray` doesn't seem to be used in ndpyramid AFAICT.

cc @andersy005 