### PR TITLE
Added method to coarsen a pyramid based on input # of levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,14 @@ import xarray as xr
 import rioxarray
 from ndpyramid import pyramid_coarsen, pyramid_reproject
 
-# load a sampel xarray.Dataset
+# load a sample xarray.Dataset
 ds = xr.tutorial.load_dataset('air_temperature')
 
-# make a coarsened pyramid
+# make a coarsened pyramid by factor
 pyramid = pyramid_coarsen(ds, factors=[16, 8, 4, 3, 2, 1], dims=['lat', 'lon'], boundary='trim')
+
+# make a coarsened pyramid by number of levels
+pyramid = pyramid_coarsen(ds, levels=3, dims=['lat', 'lon'], boundary='trim')
 
 # make a reprojected (EPSG:3857) pyramid
 ds = ds.rio.write_crs('EPSG:4326')

--- a/ndpyramid/__init__.py
+++ b/ndpyramid/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
-from .core import pyramid_coarsen, pyramid_reproject
-from .regrid import pyramid_regrid
 from ._version import __version__
+from .core import pyramid_coarsen, pyramid_coarsen_by_levels, pyramid_reproject
+from .regrid import pyramid_regrid


### PR DESCRIPTION
- Adds method `pyramid_coarsen_by_levels`. Differs slightly from `pyramid_coarsen`, which takes an input of factors and instead uses a number of levels to coarsen to. 
- Possible performance improvement as each new coarsened level is computed from the level before it, instead of the base resolution of the datasets.
- Minor typo fix in `README.md`

