### PR TITLE
Support Equidistant Cylindrical (Plate Carrée) projection

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy
   - pip
   - pooch
+  - pydantic>=1.10
   - pytest
   - pytest-cov
   - pytest-mypy
@@ -21,3 +22,4 @@ dependencies:
   - xarray-datatree>=0.0.11
   - xesmf
   - zarr
+  - cf_xarray>=0.8.0

--- a/ndpyramid/common.py
+++ b/ndpyramid/common.py
@@ -1,0 +1,33 @@
+import typing
+
+import pydantic
+import pyproj
+import rasterio.transform
+
+
+class Projection(pydantic.BaseModel):
+    name: typing.Literal['web-mercator', 'equidistant-cylindrical'] = 'web-mercator'
+    _crs: str = pydantic.PrivateAttr()
+    _proj = pydantic.PrivateAttr()
+
+    def __init__(self, **data) -> None:
+
+        super().__init__(**data)
+        epsg_codes = {'web-mercator': 'EPSG:3857', 'equidistant-cylindrical': 'EPSG:4326'}
+        self._crs = epsg_codes[self.name]
+        self._proj = pyproj.Proj(self._crs)
+
+    @pydantic.validate_arguments
+    def transform(self, *, dim:int) -> rasterio.transform.Affine:
+
+
+        if self.name == 'web-mercator':
+            return rasterio.transform.Affine.translation(-20026376.39, 20048966.10) * rasterio.transform.Affine.scale((20026376.39 * 2) / dim, -(20048966.10 * 2) / dim)
+        elif self.name == 'equidistant-cylindrical':
+            # set up the transformation matrix that maps between the Equidistant Cylindrical projection
+            # and the latitude-longitude projection. The Affine.translation function moves the origin
+            # of the grid from (0, 0) to (-180, 90) in latitude-longitude coordinates,
+            # and the Affine.scale function scales the grid coordinates to match the size of the grid
+            # in latitude-longitude coordinates. The resulting transformation matrix maps grid coordinates to
+            # latitude-longitude coordinates.
+            return rasterio.transform.Affine.translation(-180, 90) * rasterio.transform.Affine.scale(360 / dim, -180 / dim)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,14 @@ classifiers = [
 ]
 dynamic = ["version"]
 
-dependencies = ["cf_xarray", "xarray-datatree >= 0.0.11", "zarr"]
+dependencies = [
+    "cf_xarray>=0.8.0",
+    "xarray-datatree >= 0.0.11",
+    "zarr",
+    "pydantic>=1.10",
+    "rasterio",
+    "pyproj",
+]
 
 [project.urls]
 repository = "https://github.com/carbonplan/ndpyramid"

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -61,12 +61,13 @@ def test_regridded_pyramid_with_weights(temperature):
     pyramid.to_zarr(MemoryStore())
 
 
-def test_make_grid_ds():
+@pytest.mark.parametrize('projection', ['web-mercator', 'equidistant-cylindrical'])
+def test_make_grid_ds(projection):
 
-    grid = make_grid_ds(0, pixels_per_tile=8)
+    grid = make_grid_ds(0, pixels_per_tile=8, projection=projection)
     lon_vals = grid.lon_b.values
     assert np.all((lon_vals[-1, :] - lon_vals[0, :]) < 0.001)
-
+    assert grid.attrs['crs'] == 'EPSG:3857' if projection == 'web-mercator' else 'EPSG:4326'
 
 @pytest.mark.parametrize('levels', [1, 2])
 @pytest.mark.parametrize('method', ['bilinear', 'conservative'])


### PR DESCRIPTION
This PR adds support for Equidistant Cylindrical (Plate Carrée) projection when generating the target grid used by xesmf for regridding. The `web mercator` projection is still the default option

Cc @katamartin 