### PR TITLE
Update affine translation for web-mercator pyramids

### DIFF
--- a/ndpyramid/common.py
+++ b/ndpyramid/common.py
@@ -22,7 +22,7 @@ class Projection(pydantic.BaseModel):
 
 
         if self.name == 'web-mercator':
-            return rasterio.transform.Affine.translation(-20026376.39, 20048966.10) * rasterio.transform.Affine.scale((20026376.39 * 2) / dim, -(20048966.10 * 2) / dim)
+            return rasterio.transform.Affine.translation(-20037508.342789244, 20037508.342789248) * rasterio.transform.Affine.scale((20037508.342789244 * 2) / dim, -(20037508.342789248 * 2) / dim)
         elif self.name == 'equidistant-cylindrical':
             # set up the transformation matrix that maps between the Equidistant Cylindrical projection
             # and the latitude-longitude projection. The Affine.translation function moves the origin

--- a/ndpyramid/common.py
+++ b/ndpyramid/common.py
@@ -22,6 +22,9 @@ class Projection(pydantic.BaseModel):
 
 
         if self.name == 'web-mercator':
+            # set up the transformation matrix for the web-mercator projection such that the data conform
+            # to the slippy-map tiles assumed boundaries. See https://github.com/carbonplan/ndpyramid/pull/70
+            # for detailed on calculating the parameters.
             return rasterio.transform.Affine.translation(-20037508.342789244, 20037508.342789248) * rasterio.transform.Affine.scale((20037508.342789244 * 2) / dim, -(20037508.342789248 * 2) / dim)
         elif self.name == 'equidistant-cylindrical':
             # set up the transformation matrix that maps between the Equidistant Cylindrical projection


### PR DESCRIPTION
Fixes the affine transformation for global web-mercator grids

Determined based on:

```python
from pyproj import Transformer
import math

def bounds(xtile, ytile, zoom):
    """Returns the bounding box of a tile

    Parameters
    ----------
    tile : Tile or tuple
        May be be either an instance of Tile or 3 ints (X, Y, Z).

    Returns
    -------
    LngLatBbox
    from https://github.com/mapbox/mercantile/blob/fe3762d14001ca400caf7462f59433b906fc25bd/mercantile/__init__.py#L200C4-L200C4
    """

    Z2 = math.pow(2, zoom)

    ul_lon_deg = xtile / Z2 * 360.0 - 180.0
    ul_lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * ytile / Z2)))
    ul_lat_deg = math.degrees(ul_lat_rad)

    lr_lon_deg = (xtile + 1) / Z2 * 360.0 - 180.0
    lr_lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * (ytile + 1) / Z2)))
    lr_lat_deg = math.degrees(lr_lat_rad)
    
    lr_lat_deg = math.degrees(lr_lat_rad)
    return (ul_lon_deg, ul_lat_deg, lr_lon_deg, lr_lat_deg)

transformer = Transformer.from_crs("EPSG:4326", "EPSG:3857", always_xy=True)

xmin, ymin, xmax, ymax = bounds(0, 0, 0)
print('Level 0')
print(xmin, ymin, xmax, ymax)
print(transformer.transform(xmin, ymin))
print(transformer.transform(xmax, ymax))


print('\n\n Level 1')
xmin, ymin, xmax, ymax = bounds(0, 0, 1)
transformer.transform(xmin, ymin)
xmin, ymin, xmax, ymax = bounds(1, 1, 1)
print(transformer.transform(xmax, ymax))
```

```bash
Level 0
-180.0 85.0511287798066 180.0 -85.0511287798066
(-20037508.342789244, 20037508.342789248)
(20037508.342789244, -20037508.342789248)


 Level 1
(20037508.342789244, -20037508.342789248)
```
