### PR TITLE
[WIP - prototype - DO NOT MERGE] Single Level Reprojection

### DIFF
--- a/ndpyramid/__init__.py
+++ b/ndpyramid/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
-from .core import pyramid_coarsen, pyramid_reproject
+from .core import pyramid_coarsen, pyramid_reproject, reproject_single_level
 from .regrid import pyramid_regrid
 from ._version import __version__

--- a/ndpyramid/core.py
+++ b/ndpyramid/core.py
@@ -53,7 +53,7 @@ def pyramid_coarsen(
     plevels['/'] = xr.Dataset(attrs=attrs)
     return dt.DataTree.from_dict(plevels)
 
-
+# single_level branch
 def pyramid_reproject(
     ds: xr.Dataset,
     *,


### PR DESCRIPTION
This PR intends to add the ability for `ndpyramid` to create individual pyramid levels.

- [ ] Refactor the internals of `pyramid_reproject` for shared use
- [ ] Create function for single level creation
- [ ] Fixes #74


Performance improvement ideas:
- remove for loop and map over levels
- 'fast path' option to generate levels from successive levels 
- generate weights to pass to XESMF
- xr.map_blocks over non spatial dims 


cc @maxrjones @andersy005 feel free to add/edit this list.