### PR TITLE
Document coordinate array chunking requirement

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -69,6 +69,7 @@ In addition, the mapping toolkit relies on the `_ARRAY_DIMENSIONS` attribute int
 In addition to following the quadtree pyramid structure and metadata schema, the pyramids currently must also meet the following requirements for use with `@carbonplan/maps`:
 
 - Consistent chunk size across pyramid levels (128, 256, or 512 are recommended)
+- Storage of non-spatial coordinate arrays in single chunk
 - [zlib](https://numcodecs.readthedocs.io/en/stable/zlib.html) or [gzip](https://numcodecs.readthedocs.io/en/stable/gzip.html) compression
 - Web Mercator (EPSG:3857) or Equidistant Cylindrical (EPSG:4326) projection
 - Data types supported by [zarr-js](https://github.com/freeman-lab/zarr-js). The following are supported as of `v3.3.0` for Zarr v2:


### PR DESCRIPTION
Update docs to capture requirement that coordinate arrays for any non-spatial dimensions are stored in a single chunk.

For background: when `@carbonplan/maps` initializes a `Raster` layer, coordinate arrays are one of the first pieces of data the library loads because the library works with coordinate _value_ selectors instead of coordinate indices. This is a requirement that could be unwound, but it would take some work to support index-based selection.

The library also currently assumes that the array is stored in a single chunk, which we could unwind pretty easily. But as long as that first requirement is in place, issuing one request for the full array instead of potentially many chunks should generally be better for browser performance (because browser requests can be rate-limited, etc.).