### PR TITLE
Change nodata from rioxarray default to nan in pyramid_reproject

### DIFF
--- a/ndpyramid/core.py
+++ b/ndpyramid/core.py
@@ -1,10 +1,10 @@
 from __future__ import annotations  # noqa: F401
 
-import contextlib
 import typing
 from collections import defaultdict
 
 import datatree as dt
+import numpy as np
 import xarray as xr
 
 from .common import Projection
@@ -132,16 +132,13 @@ def pyramid_reproject(
         dst_transform = projection_model.transform(dim=dim)
 
         def reproject(da, var):
+            da.encoding['_FillValue'] = np.nan
             da = da.rio.reproject(
                 projection_model._crs,
                 resampling=Resampling[resampling_dict[var]],
                 shape=(dim, dim),
                 transform=dst_transform,
             )
-            da = da.where(da != da.rio.nodata)
-            with contextlib.suppress(KeyError):
-                del da.attrs['_FillValue']
-                del da.encoding['_FillValue']
             return da
 
         # create the data array for each level

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -41,7 +41,7 @@ def test_reprojected_pyramid_fill(temperature, benchmark):
     """
     pytest.importorskip('rioxarray')
     temperature = temperature.rio.write_crs('EPSG:4326')
-    pyramid = benchmark(lambda: pyramid_reproject(temperature, levels=2))
+    pyramid = benchmark(lambda: pyramid_reproject(temperature, levels=1))
     assert np.isnan(pyramid['0'].air.isel(time=0, x=0, y=0).values)
 
 

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -28,12 +28,21 @@ def test_reprojected_pyramid(temperature, benchmark):
     pytest.importorskip('rioxarray')
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
-    pyramid = benchmark(lambda: pyramid_reproject(temperature, levels=2))
+    pyramid = benchmark(lambda: pyramid_reproject(temperature, levels=levels))
     assert pyramid.ds.attrs['multiscales']
     assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == levels
     assert pyramid.ds.attrs['multiscales'][0]['datasets'][0]['crs'] == 'EPSG:3857'
-    assert np.isnan(pyramid['0'].air.isel(time=0, x=0, y=0).values)
     pyramid.to_zarr(MemoryStore())
+
+
+def test_reprojected_pyramid_fill(temperature, benchmark):
+    """
+    Test for https://github.com/carbonplan/ndpyramid/issues/93.
+    """
+    pytest.importorskip('rioxarray')
+    temperature = temperature.rio.write_crs('EPSG:4326')
+    pyramid = benchmark(lambda: pyramid_reproject(temperature, levels=2))
+    assert np.isnan(pyramid['0'].air.isel(time=0, x=0, y=0).values)
 
 
 @pytest.mark.parametrize('regridder_apply_kws', [None, {'keep_attrs': False}])

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -32,6 +32,7 @@ def test_reprojected_pyramid(temperature, benchmark):
     assert pyramid.ds.attrs['multiscales']
     assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == levels
     assert pyramid.ds.attrs['multiscales'][0]['datasets'][0]['crs'] == 'EPSG:3857'
+    assert np.isnan(pyramid['0'].air.isel(time=0, x=0, y=0).values)
     pyramid.to_zarr(MemoryStore())
 
 


### PR DESCRIPTION
Fixes #93 

Rasterio (via rioxarray) uses `_FillValue` as the value to initialize the numpy array for the reprojected output, rather than just as the value for representing missing data when serializing to disk. As shown in #93, users expect missing data instead to be represented by NaNs when in memory. This PR fills the rioxarray nodata values with np.nan. 

The `_FillValue` used for writing the DataTree is set later in `add_metadata_and_zarr_encoding`.

