### PR TITLE
Automatically standardize dtypes for int, datetime64, and object variables

### DIFF
--- a/ndpyramid/utils.py
+++ b/ndpyramid/utils.py
@@ -81,13 +81,14 @@ def set_zarr_encoding(
         Dtype to cast floating point variables to
     int_dtype : str or dtype, optional
         Dtype to cast integer variables to
-    datetime_dtype : str or dtype, optional
-        Dtype to encode numpy.datetime64 variables as.
-        Time coordinates are encoded as 'int32' if
-        `datetime_dtype` is None and cf_xarray is able to
-        identify the coordinates as representing time.
     object_dtype : str or dtype, optional
         Dtype to cast object variables to.
+    datetime_dtype : str or dtype, optional
+        Dtype to encode numpy.datetime64 variables as.
+        Time coordinates are encoded as 'int32' if cf_xarray
+        is able to identify the coordinates representing time,
+        even if `datetime_dtype` is None.
+
 
     Returns
     -------

--- a/ndpyramid/utils.py
+++ b/ndpyramid/utils.py
@@ -82,7 +82,7 @@ def set_zarr_encoding(
     int_dtype : str or dtype, optional
         Dtype to cast integer variables to
     datetime_dtype : str or dtype, optional
-        Dtype to cast numpy.datetime64 variables to.
+        Dtype to encode numpy.datetime64 variables as.
         Time coordinates are encoded as 'int32' if
         `datetime_dtype` is None and cf_xarray is able to
         identify the coordinates as representing time.
@@ -119,12 +119,11 @@ def set_zarr_encoding(
         elif np.issubdtype(da.dtype, np.integer) and int_dtype is not None:
             da = da.astype(int_dtype)
             da.encoding['dtype'] = str(int_dtype)
-        elif np.issubdtype(da.dtype, np.datetime64) and datetime_dtype is not None:
-            da = da.astype(datetime_dtype)
-            da.encoding['dtype'] = str(datetime_dtype)
         elif da.dtype == 'O' and object_dtype is not None:
             da = da.astype(object_dtype)
             da.encoding['dtype'] = str(object_dtype)
+        elif np.issubdtype(da.dtype, np.datetime64) and datetime_dtype is not None:
+            da.encoding['dtype'] = str(datetime_dtype)
         elif varname in time_vars:
             da.encoding['dtype'] = 'int32'
 

--- a/notebooks/demo.ipynb
+++ b/notebooks/demo.ipynb
@@ -141,16 +141,13 @@
     "    .squeeze()\n",
     "    .reset_coords([\"band\"], drop=True)\n",
     ")\n",
-    "ds2[\"climate\"] = ds2[\"climate\"].astype(\"float32\")\n",
     "ds2[\"climate\"].values[ds2[\"climate\"].values == ds2[\"climate\"].values[0, 0]] = ds1[\"climate\"].values[\n",
     "    0, 0\n",
     "]\n",
     "ds = xr.concat([ds1, ds2], pd.Index([\"tavg\", \"prec\"], name=\"band\"))\n",
-    "ds[\"band\"] = ds[\"band\"].astype(\"str\")\n",
     "\n",
     "# create the pyramid\n",
     "dt = pyramid_reproject(ds, levels=LEVELS, other_chunks={'band': 2}, clear_attrs=True)\n",
-    "dt.ds.attrs\n",
     "\n",
     "# write the pyramid to zarr\n",
     "dt.to_zarr(store_3d, consolidated=True)"
@@ -189,11 +186,9 @@
     "    )\n",
     "    ds_all.append(ds)\n",
     "ds = xr.concat(ds_all, pd.Index(months, name=\"month\"))\n",
-    "ds[\"month\"] = ds[\"month\"].astype(\"int32\")\n",
     "\n",
     "# create the pyramid\n",
     "dt = pyramid_reproject(ds, levels=LEVELS, other_chunks={'month': 12}, clear_attrs=True)\n",
-    "dt.ds.attrs\n",
     "\n",
     "# write the pyramid to zarr\n",
     "dt.to_zarr(store_3d_1var, consolidated=True)"
@@ -243,14 +238,10 @@
     "    )\n",
     "    ds2_all.append(ds)\n",
     "ds2 = xr.concat(ds2_all, pd.Index(months, name=\"month\"))\n",
-    "ds1[\"month\"] = ds1[\"month\"].astype(\"int32\")\n",
-    "ds2[\"month\"] = ds2[\"month\"].astype(\"int32\")\n",
-    "ds2[\"climate\"] = ds2[\"climate\"].astype(\"float32\")\n",
     "ds2[\"climate\"].values[ds2[\"climate\"].values == ds2[\"climate\"].values[0, 0, 0]] = ds1[\n",
     "    \"climate\"\n",
     "].values[0, 0, 0]\n",
     "ds = xr.concat([ds1, ds2], pd.Index([\"tavg\", \"prec\"], name=\"band\"))\n",
-    "ds[\"band\"] = ds[\"band\"].astype(\"str\")\n",
     "\n",
     "# create the pyramid\n",
     "dt = pyramid_reproject(\n",
@@ -259,8 +250,16 @@
     "dt.ds.attrs\n",
     "\n",
     "# write the pyramid to zarr\n",
-    "dt.to_zarr(store_4d, consolidated=True)"
+    "dt.to_zarr(store_4d, consolidated=True, mode=\"w\")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -274,7 +273,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.12.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds the option to cast datetime and object variables in `set_zarr_encoding` and updates the default behavior in `set_metadata_and_zarr_encoding` to update int, datetime, and object dtypes for compatibility with the `@carbonplan/maps` library.

Fixes #87