### PR TITLE
Pyramid create for creating pyramids with custom funcs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,5 +11,6 @@ Top level API
    :toctree: generated/
 
    pyramid_coarsen
+   pyramid_create
    pyramid_reproject
    pyramid_regrid

--- a/docs/generate-pyramids.md
+++ b/docs/generate-pyramids.md
@@ -23,3 +23,25 @@ pyramid = pyramid_reproject(ds, levels=2)
 # write the pyramid to zarr
 pyramid.to_zarr('./path/to/write')
 ```
+
+There's also `pyramid_create`--a more versatile alternative to pyramid_coarsen.
+
+This function accepts a custom function with the signature: `ds`, `factor`, `dims`.
+
+Here, the `sel_coarsen` function uses `ds.sel` to perform coarsening:
+
+```python
+def sel_coarsen(ds, factor, dims, **kwargs):
+    return ds.sel(**{dim: slice(None, None, factor) for dim in dims})
+
+factors = [4, 2, 1]
+pyramid = pyramid_create(
+    temperature,
+    dims=('lat', 'lon'),
+    factors=factors,
+    boundary='trim',
+    func=sel_coarsen,
+    method_label=method_label,
+    type_label='pick',
+)
+```

--- a/docs/generate-pyramids.md
+++ b/docs/generate-pyramids.md
@@ -24,7 +24,7 @@ pyramid = pyramid_reproject(ds, levels=2)
 pyramid.to_zarr('./path/to/write')
 ```
 
-There's also `pyramid_create`--a more versatile alternative to pyramid_coarsen.
+There's also `pyramid_create`--a more versatile alternative to `pyramid_coarsen`.
 
 This function accepts a custom function with the signature: `ds`, `factor`, `dims`.
 

--- a/docs/generate-pyramids.md
+++ b/docs/generate-pyramids.md
@@ -24,13 +24,13 @@ pyramid = pyramid_reproject(ds, levels=2)
 pyramid.to_zarr('./path/to/write')
 ```
 
-There's also `pyramid_create`--a more versatile alternative to `pyramid_coarsen`.
-
+There's also `pyramid_create` -- a more versatile alternative to `pyramid_coarsen`.
 This function accepts a custom function with the signature: `ds`, `factor`, `dims`.
-
 Here, the `sel_coarsen` function uses `ds.sel` to perform coarsening:
 
 ```python
+from ndpyramid import pyramid_create
+
 def sel_coarsen(ds, factor, dims, **kwargs):
     return ds.sel(**{dim: slice(None, None, factor) for dim in dims})
 
@@ -41,7 +41,7 @@ pyramid = pyramid_create(
     factors=factors,
     boundary='trim',
     func=sel_coarsen,
-    method_label=method_label,
+    method_label="slice_coarsen",
     type_label='pick',
 )
 ```

--- a/ndpyramid/__init__.py
+++ b/ndpyramid/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 
+from .create import pyramid_create
 from .coarsen import pyramid_coarsen
 from .reproject import pyramid_reproject
 from .regrid import pyramid_regrid

--- a/ndpyramid/coarsen.py
+++ b/ndpyramid/coarsen.py
@@ -23,7 +23,7 @@ def pyramid_coarsen(
         Additional keyword arguments to pass to xarray.Dataset.coarsen.
     """
 
-    def coarsen(ds: xr.Dataset, factor: int, **kwargs):
+    def coarsen(ds: xr.Dataset, factor: int, dims: list[str], **kwargs):
         # merge dictionary via union operator
         kwargs |= {d: factor for d in dims}
         return ds.coarsen(**kwargs).mean()  # type: ignore

--- a/ndpyramid/coarsen.py
+++ b/ndpyramid/coarsen.py
@@ -1,11 +1,9 @@
 from __future__ import annotations  # noqa: F401
 
-from typing import Callable
-
 import datatree as dt
 import xarray as xr
 
-from .utils import get_version, multiscales_template
+from .create import pyramid_create
 
 
 def pyramid_coarsen(
@@ -35,74 +33,7 @@ def pyramid_coarsen(
         factors=factors,
         dims=dims,
         func=coarsen,
-        method_label="pyramid_coarsen",
-        type_label="reduce",
+        method_label='pyramid_coarsen',
+        type_label='reduce',
         **kwargs,
     )
-
-
-def pyramid_create(
-    ds: xr.Dataset,
-    *,
-    factors: list[int],
-    dims: list[str],
-    func: Callable,
-    type_label: str = "reduce",
-    method_label: str | None = None,
-    **kwargs,
-):
-    """Create a multiscale pyramid via a given function applied to a dataset.
-    The generalized version of pyramid_coarsen.
-
-    Parameters
-    ----------
-    ds : xarray.Dataset
-        The dataset to apply the function to.
-    factors : list[int]
-        The factors to coarsen by.
-    dims : list[str]
-        The dimensions to coarsen.
-    func : Callable
-        The function to apply to the dataset; must accept the
-        `ds`, `factor`, and `dims` as positional arguments.
-    type_label : str, optional
-        The type label to use as metadata for the multiscales spec.
-        The default is 'reduce'.
-    method_label : str, optional
-        The method label to use as metadata for the multiscales spec.
-        The default is the name of the function.
-    kwargs : dict
-        Additional keyword arguments to pass to the func.
-
-    """
-    # multiscales spec
-    save_kwargs = locals()
-    del save_kwargs['ds']
-
-    attrs = {
-        'multiscales': multiscales_template(
-            datasets=[{'path': str(i)} for i in range(len(factors))],
-            type=type_label,
-            method=method_label or func.__name__,
-            version=get_version(),
-            kwargs=save_kwargs,
-        )
-    }
-
-    # set up pyramid
-    plevels = {}
-
-    # pyramid data
-    for key, factor in enumerate(factors):
-        plevels[str(key)] = func(ds, factor, dims, **kwargs)
-
-    plevels['/'] = xr.Dataset(attrs=attrs)
-    return dt.DataTree.from_dict(plevels)
-
-
-
-# 
-
-"""
-
-"""

--- a/ndpyramid/create.py
+++ b/ndpyramid/create.py
@@ -1,0 +1,67 @@
+from __future__ import annotations  # noqa: F401
+
+from typing import Callable
+
+import datatree as dt
+import xarray as xr
+
+from .utils import get_version, multiscales_template
+
+
+def pyramid_create(
+    ds: xr.Dataset,
+    *,
+    factors: list[int],
+    dims: list[str],
+    func: Callable,
+    type_label: str = 'reduce',
+    method_label: str | None = None,
+    **kwargs,
+):
+    """Create a multiscale pyramid via a given function applied to a dataset.
+    The generalized version of pyramid_coarsen.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to apply the function to.
+    factors : list[int]
+        The factors to coarsen by.
+    dims : list[str]
+        The dimensions to coarsen.
+    func : Callable
+        The function to apply to the dataset; must accept the
+        `ds`, `factor`, and `dims` as positional arguments.
+    type_label : str, optional
+        The type label to use as metadata for the multiscales spec.
+        The default is 'reduce'.
+    method_label : str, optional
+        The method label to use as metadata for the multiscales spec.
+        The default is the name of the function.
+    kwargs : dict
+        Additional keyword arguments to pass to the func.
+
+    """
+    # multiscales spec
+    save_kwargs = locals()
+    del save_kwargs['ds']
+
+    attrs = {
+        'multiscales': multiscales_template(
+            datasets=[{'path': str(i)} for i in range(len(factors))],
+            type=type_label,
+            method=method_label or func.__name__,
+            version=get_version(),
+            kwargs=save_kwargs,
+        )
+    }
+
+    # set up pyramid
+    plevels = {}
+
+    # pyramid data
+    for key, factor in enumerate(factors):
+        plevels[str(key)] = func(ds, factor, dims, **kwargs)
+
+    plevels['/'] = xr.Dataset(attrs=attrs)
+    return dt.DataTree.from_dict(plevels)

--- a/ndpyramid/create.py
+++ b/ndpyramid/create.py
@@ -45,6 +45,9 @@ def pyramid_create(
     # multiscales spec
     save_kwargs = locals()
     del save_kwargs['ds']
+    del save_kwargs['func']
+    del save_kwargs['type_label']
+    del save_kwargs['method_label']
 
     attrs = {
         'multiscales': multiscales_template(

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -21,7 +21,7 @@ def test_xarray_coarsened_pyramid(temperature, benchmark):
     )
     assert pyramid.ds.attrs['multiscales']
     assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == len(factors)
-    assert pyramid.ds.attrs['multiscales'][0]['method'] == 'pyramid_coarsen'
+    assert pyramid.ds.attrs['multiscales'][0]['metadata']['method'] == 'pyramid_coarsen'
     assert pyramid.ds.attrs['multiscales'][0]['type'] == 'reduce'
     pyramid.to_zarr(MemoryStore())
 
@@ -45,7 +45,7 @@ def test_xarray_custom_coarsened_pyramid(temperature, benchmark, method_label):
     )
     assert pyramid.ds.attrs['multiscales']
     assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == len(factors)
-    assert pyramid.ds.attrs['multiscales'][0]['method'] == 'sel_coarsen'
+    assert pyramid.ds.attrs['multiscales'][0]['metadata']['method'] == 'sel_coarsen'
     assert pyramid.ds.attrs['multiscales'][0]['type'] == 'pick'
     pyramid.to_zarr(MemoryStore())
 

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -26,7 +26,7 @@ def test_xarray_coarsened_pyramid(temperature, benchmark):
     pyramid.to_zarr(MemoryStore())
 
 
-@pytest.mark.parametrize("method_label", [None, "sel_coarsen"])
+@pytest.mark.parametrize('method_label', [None, 'sel_coarsen'])
 def test_xarray_custom_coarsened_pyramid(temperature, benchmark, method_label):
     def sel_coarsen(ds, factor, dims, **kwargs):
         return ds.sel(**{dim: slice(None, None, factor) for dim in dims})
@@ -45,7 +45,7 @@ def test_xarray_custom_coarsened_pyramid(temperature, benchmark, method_label):
     )
     assert pyramid.ds.attrs['multiscales']
     assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == len(factors)
-    assert pyramid.ds.attrs['multiscales'][0]['method'] == 'sel_coarsen' 
+    assert pyramid.ds.attrs['multiscales'][0]['method'] == 'sel_coarsen'
     assert pyramid.ds.attrs['multiscales'][0]['type'] == 'pick'
     pyramid.to_zarr(MemoryStore())
 


### PR DESCRIPTION
Closes https://github.com/carbonplan/ndpyramid/issues/94

Adapted pyramid_coarsen from ndpyramid [for a project](https://github.com/holoviz-topics/neuro/issues/87#issuecomment-1992668594), but I would like to add a bit of functionality back so I can simply import it.

Basic usage:
```python
def sel_coarsen(ds, factor, dims, **kwargs):
    return ds.sel(**{dim: slice(None, None, factor) for dim in dims})

factors = [4, 2, 1]
pyramid = pyramid_create(
    temperature,
    dims=('lat', 'lon'),
    factors=factors,
    boundary='trim',
    func=sel_coarsen,
    method_label=method_label,
    type_label='pick',
)
```

I think it could eventually support https://github.com/carbonplan/ndpyramid/issues/10, but haven't looked at it in detail.

More advanced, applicable use case:
```python
import h5py
import xarray as xr
import dask.array as da
import datatree as dt
from ndpyramid import pyramid_create
from tsdownsample import MinMaxLTTBDownsampler


def _help_downsample(data, time, n_out):
    indices = MinMaxLTTBDownsampler().downsample(time, data, n_out=n_out)
    return data[indices], indices


def apply_downsample(ts_ds, factor, dims):
    dim = dims[0]
    n_out = len(ts_ds["data"]) // factor
    ts_ds_downsampled, indices = xr.apply_ufunc(
        _help_downsample,
        ts_ds["data"],
        ts_ds[dim],
        kwargs=dict(n_out=n_out),
        input_core_dims=[[dim], [dim]],
        output_core_dims=[[dim], ["indices"]],
        exclude_dims=set((dim,)),
        vectorize=True,
        dask="parallelized",
        dask_gufunc_kwargs=dict(output_sizes={dim: n_out, "indices": n_out}),
    )
    ts_ds_downsampled[dim] = ts_ds[dim].isel(time=indices.values[0])
    return ts_ds_downsampled.rename("data")


def build_dataset(f, data_key, dims):
    coords = {f[dim] for dim in dims.values()}
    data = f[data_key]
    ds = xr.DataArray(
        da.from_array(data, name="data", chunks=(data.shape[0], 1)),
        dims=dims,
        coords=coords,
    ).to_dataset()
    return ds


f = h5py.File("allensdk_cache/session_715093703/probe_810755797_lfp.nwb", "r")
ts_ds = build_dataset(
    f,
    "acquisition/probe_810755797_lfp_data/data",
    {
        "time": "acquisition/probe_810755797_lfp_data/timestamps",
        "channel": "acquisition/probe_810755797_lfp_data/electrodes",
    },
).isel(channel=[0, 1, 2, 3, 4])
ts_dt = pyramid_create(
    ts_ds,
    factors=[1, 2],
    dims=["time"],
    func=apply_downsample,
    type_label="pick",
    method_label="pyramid_downsample",
)
ts_dt
```