### PR TITLE
Resample dask arrays blockwise using pyresample

### DIFF
--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -4,6 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - dask
+  - jinja2
   - esmpy>=8.2.0
   - mercantile
   - mpich
@@ -14,6 +15,7 @@ dependencies:
   - pre-commit
   - pydantic>=1.10
   - pyproj
+  - pyresample
   - pytest
   - pytest-cov
   - pytest-mypy

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,3 +14,4 @@ Top level API
    pyramid_create
    pyramid_reproject
    pyramid_regrid
+   pyramid_resample

--- a/ndpyramid/__init__.py
+++ b/ndpyramid/__init__.py
@@ -4,4 +4,5 @@ from .create import pyramid_create
 from .coarsen import pyramid_coarsen
 from .reproject import pyramid_reproject
 from .regrid import pyramid_regrid
+from .resample import pyramid_resample
 from ._version import __version__

--- a/ndpyramid/common.py
+++ b/ndpyramid/common.py
@@ -16,8 +16,18 @@ class Projection(pydantic.BaseModel):
 
         super().__init__(**data)
         epsg_codes = {'web-mercator': 'EPSG:3857', 'equidistant-cylindrical': 'EPSG:4326'}
+        area_extents = {
+            'web-mercator': (
+                -20037508.342789244,
+                -20037508.342789248,
+                20037508.342789248,
+                20037508.342789244,
+            ),
+            'equidistant-cylindrical': (-180, 180, 90, -90),
+        }
         self._crs = epsg_codes[self.name]
         self._proj = pyproj.Proj(self._crs)
+        self._area_extent = area_extents[self.name]
 
     @pydantic.validate_call
     def transform(self, *, dim: int) -> rasterio.transform.Affine:

--- a/ndpyramid/resample.py
+++ b/ndpyramid/resample.py
@@ -3,6 +3,14 @@ from __future__ import annotations  # noqa: F401
 import datatree as dt
 import numpy as np
 import xarray as xr
+from pyresample.area_config import create_area_def
+from pyresample.future.resamplers.resampler import add_crs_xy_coords, update_resampled_coords
+from pyresample.gradient import (
+    block_bilinear_interpolator,
+    gradient_resampler_indices_block,
+)
+from pyresample.resampler import resample_blocks
+from pyresample.utils.cf import load_cf_area
 
 from .common import Projection, ProjectionOptions
 from .utils import (
@@ -13,10 +21,48 @@ from .utils import (
 )
 
 
-def _da_resample(da, *, dim, projection_model):
+def _create_target_area(*, dim, projection_model):
+    return create_area_def(
+        area_id=projection_model.name,
+        projection=projection_model._crs,
+        shape=(dim, dim),
+        area_extent=projection_model._area_extent,
+    )
+
+
+def _create_source_area(da):
+    ds = da.to_dataset(name='var')
+    return load_cf_area(ds, variable='var')[0]
+
+
+def _da_resample(da, *, dim, projection_model, pixels_per_tile, other_chunk):
     if da.encoding.get('_FillValue') is None and np.issubdtype(da.dtype, np.floating):
         da.encoding['_FillValue'] = np.nan
-    return da
+    target_area_def = _create_target_area(dim=dim, projection_model=projection_model)
+    source_area_def = _create_source_area(da)
+    indices_xy = resample_blocks(
+        gradient_resampler_indices_block,
+        source_area_def,
+        [],
+        target_area_def,
+        chunk_size=(other_chunk, pixels_per_tile, pixels_per_tile),
+        dtype=float,
+    )
+    resampled = resample_blocks(
+        block_bilinear_interpolator,
+        source_area_def,
+        [da.data],
+        target_area_def,
+        dst_arrays=[indices_xy],
+        chunk_size=(other_chunk, pixels_per_tile, pixels_per_tile),
+        dtype=da.dtype,
+    )
+    resampled_da = xr.DataArray(resampled, dims=('time', 'y', 'x'))
+    resampled_da = update_resampled_coords(da, resampled_da, target_area_def)
+    resampled_da = add_crs_xy_coords(resampled_da, target_area_def)
+    resampled_da = resampled_da.drop_vars('crs')
+    resampled_da.attrs = {}
+    return resampled_da
 
 
 def level_resample(
@@ -25,6 +71,7 @@ def level_resample(
     projection: ProjectionOptions = 'web-mercator',
     level: int,
     pixels_per_tile: int = 128,
+    other_chunks: dict = None,
     clear_attrs: bool = False,
 ) -> xr.Dataset:
     """Create a level of a multiscale pyramid of a dataset via resampling.
@@ -39,6 +86,8 @@ def level_resample(
         The level of the pyramid to create.
     pixels_per_tile : int, optional
         Number of pixels per tile
+    other_chunks : dict
+        Chunks for non-spatial dims.
     clear_attrs : bool, False
         Clear the attributes of the DataArrays within the multiscale level. Default is False.
 
@@ -51,18 +100,19 @@ def level_resample(
     -------
     Pyramid generation by level is experimental and subject to change.
     """
+
+    dim = 2**level * pixels_per_tile
+    projection_model = Projection(name=projection)
     save_kwargs = {'pixels_per_tile': pixels_per_tile}
     attrs = {
         'multiscales': multiscales_template(
-            datasets=[{'path': '.', 'level': level}],
+            datasets=[{'path': '.', 'level': level, 'crs': projection_model._crs}],
             type='reduce',
             method='pyramid_resample',
             version=get_version(),
             kwargs=save_kwargs,
         )
     }
-    dim = 2**level * pixels_per_tile
-    projection_model = Projection(name=projection)
 
     # create the data array for each level
     ds_level = xr.Dataset(attrs=ds.attrs)
@@ -76,7 +126,17 @@ def level_resample(
             )
         else:
             # if the data array is not 4D, just resample it
-            ds_level[k] = _da_resample(da, dim=dim, projection_model=projection_model)
+            if other_chunks is None:
+                other_chunk = list(da.sizes.values())[0]
+            else:
+                other_chunk = list(other_chunks.values())[0]
+            ds_level[k] = _da_resample(
+                da,
+                dim=dim,
+                projection_model=projection_model,
+                pixels_per_tile=pixels_per_tile,
+                other_chunk=other_chunk,
+            )
     ds_level.attrs['multiscales'] = attrs['multiscales']
     return ds_level
 
@@ -84,6 +144,8 @@ def level_resample(
 def pyramid_resample(
     ds: xr.Dataset,
     *,
+    x: str,
+    y: str,
     projection: ProjectionOptions = 'web-mercator',
     levels: int = None,
     pixels_per_tile: int = 128,
@@ -96,6 +158,10 @@ def pyramid_resample(
     ----------
     ds : xarray.Dataset
         The dataset to create a multiscale pyramid of.
+    y : string
+        name of the variable to use as 'y' axis of the CF area definition
+    x : string
+        name of the variable to use as 'x' axis of the CF area definition
     projection : str, optional
         The projection to use. Default is 'web-mercator'.
     levels : int, optional
@@ -129,6 +195,7 @@ def pyramid_resample(
 
     # set up pyramid
     plevels = {}
+    ds = ds.rename({x: 'x', y: 'y'})
 
     # pyramid data
     for level in range(levels):
@@ -137,6 +204,7 @@ def pyramid_resample(
             projection=projection,
             level=level,
             pixels_per_tile=pixels_per_tile,
+            other_chunks=other_chunks,
             clear_attrs=clear_attrs,
         )
 

--- a/ndpyramid/resample.py
+++ b/ndpyramid/resample.py
@@ -1,0 +1,203 @@
+from __future__ import annotations  # noqa: F401
+
+from collections import defaultdict
+
+import datatree as dt
+import numpy as np
+import xarray as xr
+from rasterio.warp import Resampling
+
+from .common import Projection, ProjectionOptions
+from .utils import (
+    add_metadata_and_zarr_encoding,
+    get_levels,
+    get_version,
+    multiscales_template,
+)
+
+
+def _da_reproject(da, *, dim, crs, resampling, transform):
+    if da.encoding.get('_FillValue') is None and np.issubdtype(da.dtype, np.floating):
+        da.encoding['_FillValue'] = np.nan
+    return da.rio.reproject(
+        crs,
+        resampling=resampling,
+        shape=(dim, dim),
+        transform=transform,
+    )
+
+
+def level_reproject(
+    ds: xr.Dataset,
+    *,
+    projection: ProjectionOptions = 'web-mercator',
+    level: int,
+    pixels_per_tile: int = 128,
+    resampling: str | dict = 'average',
+    extra_dim: str = None,
+    clear_attrs: bool = False,
+) -> xr.Dataset:
+    """Create a level of a multiscale pyramid of a dataset via reprojection.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to create a multiscale pyramid of.
+    projection : str, optional
+        The projection to use. Default is 'web-mercator'.
+    level : int
+        The level of the pyramid to create.
+    pixels_per_tile : int, optional
+        Number of pixels per tile
+    resampling : dict
+        Rasterio warp resampling method to use. Keys are variable names and values are warp resampling methods.
+    extra_dim : str, optional
+        The name of the extra dimension to iterate over. Default is None.
+    clear_attrs : bool, False
+        Clear the attributes of the DataArrays within the multiscale level. Default is False.
+
+    Returns
+    -------
+    xr.Dataset
+        The multiscale pyramid level.
+
+    Warning
+    -------
+    Pyramid generation by level is experimental and subject to change.
+    """
+    save_kwargs = {'pixels_per_tile': pixels_per_tile}
+    attrs = {
+        'multiscales': multiscales_template(
+            datasets=[{'path': '.', 'level': level}],
+            type='reduce',
+            method='pyramid_reproject',
+            version=get_version(),
+            kwargs=save_kwargs,
+        )
+    }
+    dim = 2**level * pixels_per_tile
+    projection_model = Projection(name=projection)
+    dst_transform = projection_model.transform(dim=dim)
+
+    # Convert resampling from string to dictionary if necessary
+    if isinstance(resampling, str):
+        resampling_dict: dict = defaultdict(lambda: resampling)
+    else:
+        resampling_dict = resampling
+
+    # create the data array for each level
+    ds_level = xr.Dataset(attrs=ds.attrs)
+    for k, da in ds.items():
+        if clear_attrs:
+            da.attrs.clear()
+        if len(da.shape) == 4:
+            # if extra_dim is not specified, raise an error
+            if extra_dim is None:
+                raise ValueError("must specify 'extra_dim' to iterate over 4d data")
+            da_all = []
+            for index in ds[extra_dim]:
+                # reproject each index of the 4th dimension
+                da_reprojected = _da_reproject(
+                    da.sel({extra_dim: index}),
+                    dim=dim,
+                    crs=projection_model._crs,
+                    resampling=Resampling[resampling_dict[k]],
+                    transform=dst_transform,
+                )
+                da_all.append(da_reprojected)
+            ds_level[k] = xr.concat(da_all, ds[extra_dim])
+        else:
+            # if the data array is not 4D, just reproject it
+            ds_level[k] = _da_reproject(
+                da,
+                dim=dim,
+                crs=projection_model._crs,
+                resampling=Resampling[resampling_dict[k]],
+                transform=dst_transform,
+            )
+    ds_level.attrs['multiscales'] = attrs['multiscales']
+    return ds_level
+
+
+def pyramid_reproject(
+    ds: xr.Dataset,
+    *,
+    projection: ProjectionOptions = 'web-mercator',
+    levels: int = None,
+    pixels_per_tile: int = 128,
+    other_chunks: dict = None,
+    resampling: str | dict = 'average',
+    extra_dim: str = None,
+    clear_attrs: bool = False,
+) -> dt.DataTree:
+    """Create a multiscale pyramid of a dataset via reprojection.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to create a multiscale pyramid of.
+    projection : str, optional
+        The projection to use. Default is 'web-mercator'.
+    levels : int, optional
+        The number of levels to create. If None, the number of levels is
+        determined by the number of tiles in the dataset.
+    pixels_per_tile : int, optional
+        Number of pixels per tile, by default 128
+    other_chunks : dict
+        Chunks for non-spatial dims to pass to :py:meth:`~xr.Dataset.chunk`. Default is None
+    resampling : str or dict, optional
+        Rasterio warp resampling method to use. Default is 'average'.
+        If a dict, keys are variable names and values are warp resampling methods.
+    extra_dim : str, optional
+        The name of the extra dimension to iterate over. Default is None.
+    clear_attrs : bool, False
+        Clear the attributes of the DataArrays within the multiscale pyramid. Default is False.
+
+    Returns
+    -------
+    dt.DataTree
+        The multiscale pyramid.
+
+    """
+    if not levels:
+        levels = get_levels(ds)
+    save_kwargs = {'levels': levels, 'pixels_per_tile': pixels_per_tile}
+    attrs = {
+        'multiscales': multiscales_template(
+            datasets=[{'path': str(i)} for i in range(levels)],
+            type='reduce',
+            method='pyramid_reproject',
+            version=get_version(),
+            kwargs=save_kwargs,
+        )
+    }
+
+    # set up pyramid
+    plevels = {}
+
+    # pyramid data
+    for level in range(levels):
+        plevels[str(level)] = level_reproject(
+            ds,
+            projection=projection,
+            level=level,
+            pixels_per_tile=pixels_per_tile,
+            resampling=resampling,
+            extra_dim=extra_dim,
+            clear_attrs=clear_attrs,
+        )
+
+    # create the final multiscale pyramid
+    plevels['/'] = xr.Dataset(attrs=attrs)
+    pyramid = dt.DataTree.from_dict(plevels)
+
+    projection_model = Projection(name=projection)
+
+    pyramid = add_metadata_and_zarr_encoding(
+        pyramid,
+        levels=levels,
+        pixels_per_tile=pixels_per_tile,
+        other_chunks=other_chunks,
+        projection=projection_model,
+    )
+    return pyramid

--- a/ndpyramid/resample.py
+++ b/ndpyramid/resample.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # noqa: F401
 
+import warnings
 from collections import defaultdict
 
 import datatree as dt
@@ -50,7 +51,11 @@ def _da_resample(da, *, dim, projection_model, pixels_per_tile, other_chunk, res
     )
     try:
         source_area_def = load_cf_area(da.to_dataset(name='var'), variable='var')[0]
-    except ValueError:
+    except ValueError as e:
+        warnings.warn(
+            f"Automatic determination of source AreaDefinition from CF conventions failed with {e}."
+            ' Falling back to AreaDefinition creation from coordinates.'
+        )
         lx = da.x[0] - (da.x[1] - da.x[0]) / 2
         rx = da.x[-1] + (da.x[-1] - da.x[-2]) / 2
         uy = da.y[0] - (da.y[1] - da.y[0]) / 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,17 @@ dependencies = [
     "pyproj",
 ]
 
-
 [project.optional-dependencies]
+dask = [
+    "dask",
+    "pyresample",
+]
+jupyter = [
+    'notebook',
+    'ipytree>=0.2.2',
+    'ipywidgets>=8.0.0',
+    'matplotlib'
+]
 test = [
     "dask",
     "mercantile",

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -81,6 +81,7 @@ def test_reprojected_pyramid_fill(temperature, benchmark):
 
 
 def test_resampled_pyramid(temperature, benchmark):
+    pytest.importorskip('pyresample')
     pytest.importorskip('rioxarray')
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
@@ -97,6 +98,7 @@ def test_resampled_pyramid_fill(temperature, benchmark):
     """
     Test for https://github.com/carbonplan/ndpyramid/issues/93.
     """
+    pytest.importorskip('pyresample')
     pytest.importorskip('rioxarray')
     temperature = temperature.rio.write_crs('EPSG:4326')
     pyramid = benchmark(lambda: pyramid_resample(temperature, levels=1, x='lon', y='lat'))

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -80,7 +80,8 @@ def test_reprojected_pyramid_fill(temperature, benchmark):
     assert np.isnan(pyramid['0'].air.isel(time=0, x=0, y=0).values)
 
 
-def test_resampled_pyramid(temperature, benchmark):
+@pytest.mark.parametrize('resampling', ['bilinear', 'nearest'])
+def test_resampled_pyramid(temperature, benchmark, resampling):
     pytest.importorskip('pyresample')
     pytest.importorskip('rioxarray')
     levels = 2
@@ -88,7 +89,11 @@ def test_resampled_pyramid(temperature, benchmark):
     temperature = temperature.isel(time=0).drop('time')
     # import pdb; pdb.set_trace()
 
-    pyramid = benchmark(lambda: pyramid_resample(temperature, levels=levels, x='lon', y='lat'))
+    pyramid = benchmark(
+        lambda: pyramid_resample(
+            temperature, levels=levels, x='lon', y='lat', resampling=resampling
+        )
+    )
     verify_bounds(pyramid)
     assert pyramid.ds.attrs['multiscales']
     assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == levels

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -85,6 +85,22 @@ def test_resampled_pyramid(temperature, benchmark):
     pytest.importorskip('rioxarray')
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
+    temperature = temperature.isel(time=0).drop('time')
+    pyramid = benchmark(lambda: pyramid_resample(temperature, levels=levels, x='lon', y='lat'))
+    verify_bounds(pyramid)
+    assert pyramid.ds.attrs['multiscales']
+    assert len(pyramid.ds.attrs['multiscales'][0]['datasets']) == levels
+    assert pyramid.attrs['multiscales'][0]['datasets'][0]['crs'] == 'EPSG:3857'
+    assert pyramid['0'].attrs['multiscales'][0]['datasets'][0]['crs'] == 'EPSG:3857'
+    pyramid.to_zarr(MemoryStore())
+
+
+def test_resampled_pyramid_2D(temperature, benchmark):
+    pytest.importorskip('pyresample')
+    pytest.importorskip('rioxarray')
+    levels = 2
+    temperature = temperature.rio.write_crs('EPSG:4326')
+    temperature = temperature.isel(time=0).drop('time')
     pyramid = benchmark(lambda: pyramid_resample(temperature, levels=levels, x='lon', y='lat'))
     verify_bounds(pyramid)
     assert pyramid.ds.attrs['multiscales']

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -86,6 +86,8 @@ def test_resampled_pyramid(temperature, benchmark):
     levels = 2
     temperature = temperature.rio.write_crs('EPSG:4326')
     temperature = temperature.isel(time=0).drop('time')
+    # import pdb; pdb.set_trace()
+
     pyramid = benchmark(lambda: pyramid_resample(temperature, levels=levels, x='lon', y='lat'))
     verify_bounds(pyramid)
     assert pyramid.ds.attrs['multiscales']


### PR DESCRIPTION
New attempt at implementing https://github.com/carbonplan/ndpyramid/issues/10 using pyresample's `resample_blocks`.

To-do:
- [x] Test values of pyramid data in addition to coords
- [ ] Infer x/y dimensions from CF conventions
- [ ] Add test for non-CF compliant data
- [x] Test 2D dataset
- [x] Add documentation. Note: Include a warning about dims order (time,y,x)

I think we could add support for 4D data as a separate PR.