### PR TITLE
Fix area extents for pyramid_resample

### DIFF
--- a/ndpyramid/common.py
+++ b/ndpyramid/common.py
@@ -16,14 +16,15 @@ class Projection(pydantic.BaseModel):
 
         super().__init__(**data)
         epsg_codes = {'web-mercator': 'EPSG:3857', 'equidistant-cylindrical': 'EPSG:4326'}
+        # Area extent for pyresample's `create_area_def` is (lower_left_x, lower_left_y, upper_right_x, upper_right_y)
         area_extents = {
             'web-mercator': (
                 -20037508.342789244,
                 -20037508.342789248,
-                20037508.342789248,
                 20037508.342789244,
+                20037508.342789248,
             ),
-            'equidistant-cylindrical': (-180, 180, 90, -90),
+            'equidistant-cylindrical': (-180, 90, 180, -90),
         }
         self._crs = epsg_codes[self.name]
         self._proj = pyproj.Proj(self._crs)

--- a/tests/test_pyramid_resample.py
+++ b/tests/test_pyramid_resample.py
@@ -97,19 +97,20 @@ def test_resampled_pyramid_fill(temperature, benchmark):
     assert np.isnan(pyramid['0'].air.isel(time=0, x=0, y=0).values)
 
 
-@pytest.mark.xfail(reseason='Differences between rasterio and pyresample to be investigated')
-def test_reprojected_resample_pyramid_values(temperature, benchmark):
+@pytest.mark.parametrize(
+    'method',
+    [
+        pytest.param(
+            'bilinear',
+            marks=pytest.mark.xfail(reason='Need to investigate differences for bilinear'),
+        ),
+        'nearest',
+    ],
+)
+def test_reprojected_resample_pyramid_values(dataset_3d, method, benchmark):
     pytest.importorskip('rioxarray')
     levels = 2
-    temperature = temperature.rio.write_crs('EPSG:4326')
-    temperature = temperature.chunk({'time': 10, 'lat': 10, 'lon': 10})
-    reprojected = benchmark(
-        lambda: pyramid_reproject(temperature, levels=levels, resampling='nearest')
-    )
-    resampled = benchmark(
-        lambda: pyramid_resample(
-            temperature, levels=levels, x='lon', y='lat', resampling='nearest_neighbour'
-        )
-    )
+    reprojected = pyramid_reproject(dataset_3d, levels=levels, resampling=method)
+    resampled = pyramid_resample(dataset_3d, levels=levels, x='x', y='y', resampling=method)
     xr.testing.assert_allclose(reprojected['0'].ds, resampled['0'].ds)
     xr.testing.assert_allclose(reprojected['1'].ds, resampled['1'].ds)

--- a/tests/test_pyramids.py
+++ b/tests/test_pyramids.py
@@ -89,7 +89,7 @@ def test_reprojected_pyramid_4d(dataset_4d, benchmark):
     pytest.importorskip('rioxarray')
     levels = 2
     with pytest.raises(Exception):
-        pyramid = benchmark(lambda: pyramid_reproject(dataset_4d, levels=levels))
+        pyramid = pyramid_reproject(dataset_4d, levels=levels)
     pyramid = benchmark(lambda: pyramid_reproject(dataset_4d, levels=levels, extra_dim='band'))
     verify_bounds(pyramid)
     assert pyramid.ds.attrs['multiscales']


### PR DESCRIPTION
The area extents weren't in the proper order of `(lower_left_x, lower_left_y, upper_right_x, upper_right_y)` for pyresample's `create_area_def`. This PR fixes the order.