### PR TITLE
Pin NumPy to <2.0.0

### DIFF
--- a/ci/doc.yml
+++ b/ci/doc.yml
@@ -9,6 +9,7 @@ dependencies:
   - sphinx>=5.0
   - sphinx-book-theme >= 0.3.0
   - numpydoc
+  - numpy<2.0.0
   - myst-parser
   - pip:
       - -e "..[xesmf]"

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - mercantile
   - mpich
   - netcdf4
-  - numpy
+  - numpy<2.0.0
   - pip
   - pooch
   - pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,12 @@ dynamic = ["version"]
 
 dependencies = [
     "cf_xarray>=0.8.0",
-    "xarray-datatree >= 0.0.11",
+    "xarray-datatree>=0.0.11",
     "zarr",
     "pydantic>=1.10",
     "pyproj",
     "rasterio",
+    "numpy<2.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR temporarily pins NumPy to avoid issues with `pyramid_regrid`. I will open an issue for tracking support and more details on the error.